### PR TITLE
Change from sercom to Hardware-Serial

### DIFF
--- a/include/aledd1.h
+++ b/include/aledd1.h
@@ -14,8 +14,8 @@
 void prepareSerial(){
     Debug.println(F("Prepare serial"));
     SerialKNX.begin(19200, SERIAL_8E1);
-    pinPeripheral(0, PIO_SERCOM_ALT);
-    pinPeripheral(1, PIO_SERCOM_ALT);
+    //pinPeripheral(0, PIO_SERCOM_ALT); //Not needed because of HardwareSerial!
+    //pinPeripheral(1, PIO_SERCOM_ALT);
     Debug.println(F("Prepare serial *DONE*"));
 }
 

--- a/include/aledd1.h
+++ b/include/aledd1.h
@@ -2,20 +2,13 @@
 
 #include "wiring_private.h" //for pinPeripheral
 
-//create a new Serial on Pins 1=TX and 0=RX
-Uart SerialKNX (&sercom2, 0, 1, SERCOM_RX_PAD_3, UART_TX_PAD_2); // Onboard TX&RX Pin
-//Interrupt handler for SerialKNX
-void SERCOM2_Handler()
-{
-    SerialKNX.IrqHandler();
-}
-
 //Hardware settings 
 #define PROG_BUTTON_PIN 3 //active low
 #define PROG_LED_PIN LED_BUILTIN
 #define LED_STRIP_PIN 5 //5V Pin!
 #define POWER_SUPPLY_PIN 4 //active low
 #define EEPROM_EMULATION_SIZE 2048
+#define SerialKNX Serial1 // Pin 0=RX 1=TX
 
 // custom serial port preparation function
 void prepareSerial(){


### PR DESCRIPTION
The original ALEDD uses Sercom to talk to the KNX-BCU. Change this to Hardware-Serial of the ItsyBitsy M0